### PR TITLE
Release 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2020-10-09
+### Added
+- flask_restx request logging now log processing_time in case of failure as well.
+- Explicit support for python 3.9
+
+### Changed
+- Only store one request id per query.
+- flask_restx request logging now log request details as a dictionary linked to request key.
+- flask_restx request logging now log request arguments as a dictionary linked to request.args key.
+- flask_restx request logging now log request headers as a dictionary linked to request.headers key.
+- flask_restx request logging now log request error as a dictionary linked to error key.
+- flask_restx request logging now log status as `end` instead of `success` as it might be misleading if app is sending failure response.
+
+### Fixed
+- flask_restx request logging do not log request data in case of exception anymore as it might be too big or bytes could not be supported by the logger.
+- flask_restx request logging now log all params as a list of values, only the first value for each param was logged previously.
+
 ## [2.1.0] - 2020-09-30
 ### Added
 - Add support for `flask-restx` framework.
@@ -36,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layab/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layab/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/Colin-b/layab/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Colin-b/layab/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Colin-b/layab/compare/v2.0.0a1...v2.0.0
 [2.0.0a1]: https://github.com/Colin-b/layab/compare/v1.5.0...v2.0.0a1

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ async def health_check():
 namespace = api.namespace(
     "Monitoring", path="/", description="Monitoring operations"
 )
-add_consul_health_endpoint(namespace, health_check)
+# You now have to set the release_id yourself
+add_consul_health_endpoint(namespace, health_check, release_id="1.0.0")
 # You now have to set the path to the changelog yourself
 changelog_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "CHANGELOG.md")
 add_changelog_endpoint(namespace, changelog_path)

--- a/layab/version.py
+++ b/layab/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["api", "starlette", "flask", "flask-restx", "configuration", "proxyfix"],

--- a/tests/test_flask_restx_logging.py
+++ b/tests/test_flask_restx_logging.py
@@ -73,28 +73,44 @@ def mock_uuid(monkeypatch):
 
 def test_log_get_request_details(client, caplog, mock_uuid):
     caplog.set_level(logging.INFO)
-    response = client.get("/logging")
+    response = client.get("/logging?param1=1&param2=test&param1=toto")
     assert response.status_code == 200
     assert response.data == b""
     assert len(caplog.messages) == 2
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "GET",
-        "request_status": "start",
-        "request_url.path": "/logging",
+        "request": {
+            "args": {
+                "param1": ["1", "toto"],
+                "param2": ["test"],
+            },
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "GET",
+            "status": "start",
+            "url.path": "/logging",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("request_processing_time")
+    end_message["request"].pop("processing_time")
     assert end_message == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "GET",
-        "request_status": "success",
-        "request_status_code": 200,
-        "request_url.path": "/logging",
+        "request": {
+            "args": {
+                "param1": ["1", "toto"],
+                "param2": ["test"],
+            },
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "GET",
+            "status": "end",
+            "status_code": 200,
+            "url.path": "/logging",
+        },
     }
 
 
@@ -105,23 +121,33 @@ def test_log_delete_request_details(client, caplog, mock_uuid):
     assert response.data == b""
     assert len(caplog.messages) == 2
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "DELETE",
-        "request_status": "start",
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "DELETE",
+            "status": "start",
+            "url.path": "/logging",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("request_processing_time")
+    end_message["request"].pop("processing_time")
     assert end_message == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "DELETE",
-        "request_status": "success",
-        "request_status_code": 200,
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "DELETE",
+            "status": "end",
+            "status_code": 200,
+            "url.path": "/logging",
+        },
     }
 
 
@@ -132,23 +158,33 @@ def test_log_post_request_details(client, caplog, mock_uuid):
     assert response.data == b""
     assert len(caplog.messages) == 2
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "POST",
-        "request_status": "start",
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "POST",
+            "status": "start",
+            "url.path": "/logging",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("request_processing_time")
+    end_message["request"].pop("processing_time")
     assert end_message == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "POST",
-        "request_status": "success",
-        "request_status_code": 200,
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "POST",
+            "status": "end",
+            "status_code": 200,
+            "url.path": "/logging",
+        },
     }
 
 
@@ -159,23 +195,33 @@ def test_log_put_request_details(client, caplog, mock_uuid):
     assert response.data == b""
     assert len(caplog.messages) == 2
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "PUT",
-        "request_status": "start",
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "PUT",
+            "status": "start",
+            "url.path": "/logging",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("request_processing_time")
+    end_message["request"].pop("processing_time")
     assert end_message == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "PUT",
-        "request_status": "success",
-        "request_status_code": 200,
-        "request_url.path": "/logging",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "PUT",
+            "status": "end",
+            "status_code": 200,
+            "url.path": "/logging",
+        },
     }
 
 
@@ -186,25 +232,37 @@ def test_log_get_request_details_on_failure(client, caplog, mock_uuid):
     assert response.data == b'{"message": "Internal Server Error"}\n'
     assert len(caplog.messages) == 3
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "GET",
-        "request_status": "start",
-        "request_url.path": "/logging_failure",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "GET",
+            "status": "start",
+            "url.path": "/logging_failure",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("error.traceback")
+    end_message["request"].pop("processing_time")
+    end_message["error"].pop("traceback")
     assert end_message == {
-        "error.class": "Exception",
-        "error.msg": "Error message",
-        "request.data": b"",
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "GET",
-        "request_status": "error",
-        "request_url.path": "/logging_failure",
+        "error": {
+            "class": "Exception",
+            "msg": "Error message",
+        },
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "GET",
+            "status": "error",
+            "url.path": "/logging_failure",
+        },
     }
 
 
@@ -215,25 +273,37 @@ def test_log_delete_request_details_on_failure(client, caplog, mock_uuid):
     assert response.data == b'{"message": "Internal Server Error"}\n'
     assert len(caplog.messages) == 3
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "DELETE",
-        "request_status": "start",
-        "request_url.path": "/logging_failure",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "DELETE",
+            "status": "start",
+            "url.path": "/logging_failure",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("error.traceback")
+    end_message["request"].pop("processing_time")
+    end_message["error"].pop("traceback")
     assert end_message == {
-        "error.class": "Exception",
-        "error.msg": "Error message",
-        "request.data": b"",
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "DELETE",
-        "request_status": "error",
-        "request_url.path": "/logging_failure",
+        "error": {
+            "class": "Exception",
+            "msg": "Error message",
+        },
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "DELETE",
+            "status": "error",
+            "url.path": "/logging_failure",
+        },
     }
 
 
@@ -244,25 +314,37 @@ def test_log_post_request_details_on_failure(client, caplog, mock_uuid):
     assert response.data == b'{"message": "Internal Server Error"}\n'
     assert len(caplog.messages) == 3
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "POST",
-        "request_status": "start",
-        "request_url.path": "/logging_failure",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "POST",
+            "status": "start",
+            "url.path": "/logging_failure",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("error.traceback")
+    end_message["request"].pop("processing_time")
+    end_message["error"].pop("traceback")
     assert end_message == {
-        "error.class": "Exception",
-        "error.msg": "Error message",
-        "request.data": b"",
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "POST",
-        "request_status": "error",
-        "request_url.path": "/logging_failure",
+        "error": {
+            "class": "Exception",
+            "msg": "Error message",
+        },
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "POST",
+            "status": "error",
+            "url.path": "/logging_failure",
+        },
     }
 
 
@@ -273,25 +355,37 @@ def test_log_put_request_details_on_failure(client, caplog, mock_uuid):
     assert response.data == b'{"message": "Internal Server Error"}\n'
     assert len(caplog.messages) == 3
     assert eval(caplog.messages[0]) == {
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "PUT",
-        "request_status": "start",
-        "request_url.path": "/logging_failure",
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "PUT",
+            "status": "start",
+            "url.path": "/logging_failure",
+        },
     }
     end_message = eval(caplog.messages[1])
-    end_message.pop("error.traceback")
+    end_message["request"].pop("processing_time")
+    end_message["error"].pop("traceback")
     assert end_message == {
-        "error.class": "Exception",
-        "error.msg": "Error message",
-        "request.data": b"",
-        "request_headers.Host": "localhost",
-        "request_headers.User-Agent": "werkzeug/1.0.1",
-        "request_id": "1-2-3-4-5",
-        "request_method": "PUT",
-        "request_status": "error",
-        "request_url.path": "/logging_failure",
+        "error": {
+            "class": "Exception",
+            "msg": "Error message",
+        },
+        "request": {
+            "args": {},
+            "headers": {
+                "Host": "localhost",
+                "User-Agent": "werkzeug/1.0.1",
+            },
+            "id": "1-2-3-4-5",
+            "method": "PUT",
+            "status": "error",
+            "url.path": "/logging_failure",
+        },
     }
 
 


### PR DESCRIPTION
### Added
- flask_restx request logging now log processing_time in case of failure as well.
- Explicit support for python 3.9

### Changed
- Only store one request id per query.
- flask_restx request logging now log request details as a dictionary linked to request key.
- flask_restx request logging now log request arguments as a dictionary linked to request.args key.
- flask_restx request logging now log request headers as a dictionary linked to request.headers key.
- flask_restx request logging now log request error as a dictionary linked to error key.
- flask_restx request logging now log status as `end` instead of `success` as it might be misleading if app is sending failure response.

### Fixed
- flask_restx request logging do not log request data in case of exception anymore as it might be too big or bytes could not be supported by the logger.
- flask_restx request logging now log all params as a list of values, only the first value for each param was logged previously.
